### PR TITLE
(#4) Update to use latest version of hypertest

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "HyperTest"]
 	path = HyperTest
-	url = https://github.com/brokenprogrammer/HyperTest
+	url = https://github.com/Nullsson/HyperTest

--- a/test/build.bat
+++ b/test/build.bat
@@ -1,5 +1,4 @@
-  
-set CommonCompilerFlags=-Od -MTd -nologo -fp:fast -fp:except- -Gm- -GR- -EHa- -Zo -Oi -WX -W4 -wd4201 -wd4100 -wd4189 -wd4505 -wd4127 -FC -Z7
-set CommonLinkerFlags= -incremental:no -opt:ref user32.lib gdi32.lib winmm.lib
+set CommonCompilerFlags=-nologo /Zi 
+set CommonLinkerFlags=-incremental:no
 
-cl %CommonCompilerFlags% -D_CRT_SECURE_NO_WARNINGS .\stn_unittest.cpp /link %CommonLinkerFlags%
+cl %CommonCompilerFlags% -DBUILD_WINDOWS=1 -DBUILD_LINUX=0 -D_CRT_SECURE_NO_WARNINGS stn_unittest.cpp /link %CommonLinkerFlags%

--- a/test/stn_unittest.cpp
+++ b/test/stn_unittest.cpp
@@ -1,30 +1,20 @@
-#include "../HyperTest/code/win32_hypertest.cpp"
-
-#define STN_NO_TYPES
+#include "../HyperTest/code/hypertest.cpp"
 #include "../stn.h"
 
 TEST(STN, Max)
 {
-    u32 Big = 1250;
-    u32 Small = 500;
-
-    UNITTEST_ASSERT_TRUE(STN_Max(Big, Small) == 1250);
-
-    Big = 420;
-    Small = 4000;
-
-    UNITTEST_ASSERT_TRUE(STN_Max(Small, Big) == 4000);
+    UNITTEST_ASSERT_TRUE(STN_Max(1250, 500) == 1250);
+    UNITTEST_ASSERT_TRUE(STN_Max(4000, 420) == 4000);
+    UNITTEST_ASSERT_TRUE(STN_Max(0, 0) == 0);
+    UNITTEST_ASSERT_TRUE(STN_Max(1, 0) == 1);
+    UNITTEST_ASSERT_TRUE(STN_Max(0, 1) == 1);
 }
 
 TEST(STN, Min)
 {
-    u32 Big = 502584;
-    u32 Small = 2359;
-
-    UNITTEST_ASSERT_TRUE(STN_Min(Big, Small) == 2359);
-
-    Big = 4392;
-    Small = 9765;
-
-    UNITTEST_ASSERT_TRUE(STN_Min(Big, Small) == 4392);
+    UNITTEST_ASSERT_TRUE(STN_Min(502584, 2359) == 2359);
+    UNITTEST_ASSERT_TRUE(STN_Min(4392, 9765) == 4392);
+    UNITTEST_ASSERT_TRUE(STN_Min(0, 0) == 0);
+    UNITTEST_ASSERT_TRUE(STN_Min(1, 0) == 0);
+    UNITTEST_ASSERT_TRUE(STN_Min(0, 1) == 0);
 }


### PR DESCRIPTION
Updated to use the new submodule path since the repository has been moved. 
Updated the existing unit test to take account for changes in the HyperTest library.

Resolves #4 